### PR TITLE
修改自动脚本里swipe的值

### DIFF
--- a/wechat_jump_auto.py
+++ b/wechat_jump_auto.py
@@ -20,7 +20,7 @@ def jump(distance):
     press_time = max(press_time, 200)
     press_time = int(press_time)
     # TODO: 坐标根据截图的 size 来计算
-    cmd = 'adb shell input swipe 500 1600 500 1601 ' + str(press_time)
+    cmd = 'adb shell input swipe 320 410 320 410 ' + str(press_time)
     print cmd
     os.system(cmd)
 


### PR DESCRIPTION
对于一些手机1600的值太大了，导致跳不起来，比如 `红米4X`，现将其和wechat_jump.py统一。
其实对于这个用0 0 0 0 就好吧？

 猜测 https://github.com/wangshub/wechat_jump_game/issues/11 会不会也是这个问题