### PR TITLE
计算不同分辨率的按压位置

### DIFF
--- a/wechat_jump_auto.py
+++ b/wechat_jump_auto.py
@@ -58,6 +58,13 @@ def save_debug_creenshot(ts, im, piece_x, piece_y, board_x, board_y):
     del draw
     im.save("{}{}_d.png".format(screenshot_backup_dir, ts))
 
+def set_button_position(im):
+    # 将swipe设置为 `再来一局` 按钮的位置
+    global swipe_x1, swipe_y1, swipe_x2, swipe_y2
+    w, h = im.size
+    left = w / 2
+    top = 1003 * (h / 1280.0) + 10
+    swipe_x1, swipe_y1, swipe_x2, swipe_y2 = left, top, left, top
 
 def jump(distance):
     press_time = distance * press_coefficient
@@ -129,6 +136,7 @@ def main():
         piece_x, piece_y, board_x, board_y = find_piece_and_board(im)
         ts = int(time.time())
         print(ts, piece_x, piece_y, board_x, board_y)
+        set_button_position(im)
         jump(math.sqrt((board_x - piece_x) ** 2 + (board_y - piece_y) ** 2))
         save_debug_creenshot(ts, im, piece_x, piece_y, board_x, board_y)
         backup_screenshot(ts)


### PR DESCRIPTION
以 `720 * 1280` 为基础得知 `再来一局`按钮距屏幕高度约 `1003px`，通过不同机型对比得出该游戏在不同设备上应该是等比缩放的，所以根据分辨率计算出 `scale` 值，然后再处理按钮位置。

测试分辨率`720 * 1280` `1080 * 1920` `750 * 1334`