### PR TITLE
优化棋子和棋盘的识别过程，减少运行时间

### DIFF
--- a/wechat_jump_auto.py
+++ b/wechat_jump_auto.py
@@ -76,9 +76,25 @@ def find_piece_and_board(im):
     piece_y_max = 0
     board_x = 0
     board_y = 0
+    scan_x_border = int(w / 8)  # 扫描棋子时的左右边界
+    scan_start_y = 0  # 扫描的起始y坐标
 
-    for i in range(h):
-        for j in range(w):
+    # 以50px步长，尝试探测scan_start_y
+    for i in range(under_game_score_y, h, 50):
+        last_pixel = im.getpixel((0, i))
+        for j in range(1, w):
+            pixel = im.getpixel((j, i))
+            # 不是纯色的线，则记录scan_start_y的值，准备跳出循环
+            if pixel[0] != last_pixel[0] or pixel[1] != last_pixel[1] or pixel[2] != last_pixel[2]:
+                scan_start_y = i - 50
+                break
+        if scan_start_y:
+            break
+    print("scan_start_y: ", scan_start_y)
+
+    # 从scan_start_y开始往下扫描，棋子应位于屏幕上半部分，这里暂定不超过2/3
+    for i in range(scan_start_y, int(h * 2 / 3)):
+        for j in range(scan_x_border, w - scan_x_border):  # 横坐标方面也减少了一部分扫描开销
             pixel = im.getpixel((j, i))
             # 根据棋子的最低行的颜色判断，找最后一行那些点的平均值，这个颜色这样应该 OK，暂时不提出来
             if (50 < pixel[0] < 60) and (53 < pixel[1] < 63) and (95 < pixel[2] < 110):
@@ -91,9 +107,7 @@ def find_piece_and_board(im):
     piece_x = piece_x_sum / piece_x_c
     piece_y = piece_y_max - piece_base_height_1_2  # 上移棋子底盘高度的一半
 
-    for i in range(h):
-        if i < under_game_score_y:
-            continue
+    for i in range(scan_start_y, h):
         last_pixel = im.getpixel((0, i))
         if board_x or board_y:
             break


### PR DESCRIPTION
原来的程序基本上是全图从上到下进行扫描，耗时较大，在我机子上find_piece_and_board方法需要将近4s。

改进为：

1、探测棋子和棋盘的扫描起始y坐标
从under_game_score_y开始，以50px为单位，向下探测是否存在纯色线，如果有纯色线则+50px继续探测，直到遇到非纯色线为止。

2、优化定位棋子时的扫描坐标范围
棋子不会太靠下，也不会太靠左/靠右。依据前者，可将棋子的扫描终止y坐标定位图片高度的2/3；依据后者，可以设定扫描棋子时的左右边界，这里暂定为宽度的1/8。

改进后，我机子上find_piece_and_board方法执行时间在0.7s-1s左右，快了4-5倍。

