### PR TITLE
Fix screenshot name inconsistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 test/
 pic/
 screenshot_backups/
-1.png
+autojump.png

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ QQ群：github微信跳一跳 **314659953**
 - 如果你是ios，请运行：`wechat_jump_iOS_py3.py`
 - 更新了一些分辨率参数配置，请按照你的手机分辨率从`config/`文件夹找到相应的配置，拷贝到*.py同级目录;
 - 注意：别刷太高，已经有同学遇到分数清零的情况了[164](https://github.com/wangshub/wechat_jump_game/issues/164)
-- 如果有找不到`./1.png`图片的错误，请查阅[194](https://github.com/wangshub/wechat_jump_game/issues/194)
+- 如果有找不到`./autojump.png`图片的错误，请查阅[194](https://github.com/wangshub/wechat_jump_game/issues/194)
 
 ## 游戏模式
 

--- a/wechat_jump.py
+++ b/wechat_jump.py
@@ -26,9 +26,9 @@ def search(img):
 
 def pull_screenshot():
     filename = datetime.datetime.now().strftime("%H%M%S") + '.png'
-    os.system('mv 1.png {}'.format(filename))
-    os.system('adb shell screencap -p /sdcard/1.png')
-    os.system('adb pull /sdcard/1.png .')
+    os.system('mv autojump.png {}'.format(filename))
+    os.system('adb shell screencap -p /sdcard/autojump.png')
+    os.system('adb pull /sdcard/autojump.png .')
 
 def jump(distance):
     press_time = distance * 1.35
@@ -40,7 +40,7 @@ def jump(distance):
 def update_data():
     global src_x, src_y
 
-    img = cv2.imread('1.png')
+    img = cv2.imread('autojump.png')
     img = cv2.resize(img, (0, 0), fx=scale, fy=scale)
 
     img, src_x, src_y = search(img)

--- a/wechat_jump_auto.py
+++ b/wechat_jump_auto.py
@@ -74,18 +74,18 @@ if not os.path.isdir(screenshot_backup_dir):
 
 
 def pull_screenshot():
-    flag = os.system('adb shell screencap -p /sdcard/1.png')
+    flag = os.system('adb shell screencap -p /sdcard/autojump.png')
     if flag == 1:
         print('请安装ADB并配置环境变量')
         sys.exit()
-    os.system('adb pull /sdcard/1.png .')
+    os.system('adb pull /sdcard/autojump.png .')
 
 
 def backup_screenshot(ts):
     # 为了方便失败的时候 debug
     if not os.path.isdir(screenshot_backup_dir):
         os.mkdir(screenshot_backup_dir)
-    shutil.copy('1.png', '{}{}.png'.format(screenshot_backup_dir, ts))
+    shutil.copy('autojump.png', '{}{}.png'.format(screenshot_backup_dir, ts))
 
 
 def save_debug_creenshot(ts, im, piece_x, piece_y, board_x, board_y):
@@ -196,7 +196,7 @@ def find_piece_and_board(im):
 def main():
     while True:
         pull_screenshot()
-        im = Image.open('./1.png')
+        im = Image.open('./autojump.png')
         # 获取棋子和 board 的位置
         piece_x, piece_y, board_x, board_y = find_piece_and_board(im)
         ts = int(time.time())

--- a/wechat_jump_iOS_py3.py
+++ b/wechat_jump_iOS_py3.py
@@ -15,7 +15,7 @@ c = wda.Client()
 s = c.session()
 
 def pull_screenshot():
-    c.screenshot('1.png')
+    c.screenshot('autojump.png')
 
 def jump(distance):
     press_time = distance * time_coefficient
@@ -27,14 +27,14 @@ fig = plt.figure()
 index = 0
 cor = [0, 0]
 pull_screenshot()
-img = np.array(Image.open('1.png'))
+img = np.array(Image.open('autojump.png'))
 
 update = True
 click_count = 0
 cor = []
 
 def update_data():
-    return np.array(Image.open('1.png'))
+    return np.array(Image.open('autojump.png'))
 
 im = plt.imshow(img, animated=True)
 

--- a/wechat_jump_py3.py
+++ b/wechat_jump_py3.py
@@ -7,8 +7,8 @@ import time
 import os
 
 def pull_screenshot():
-    os.system('adb shell screencap -p /sdcard/1.png')
-    os.system('adb pull /sdcard/1.png .')
+    os.system('adb shell screencap -p /sdcard/autojump.png')
+    os.system('adb pull /sdcard/autojump.png .')
 
 def jump(distance):
     press_time = distance * 1.35
@@ -22,14 +22,14 @@ index = 0
 cor = [0, 0]
 
 pull_screenshot()
-img = np.array(Image.open('1.png'))
+img = np.array(Image.open('autojump.png'))
 
 update = True 
 click_count = 0
 cor = []
 
 def update_data():
-    return np.array(Image.open('1.png'))
+    return np.array(Image.open('autojump.png'))
 
 im = plt.imshow(img, animated=True)
 

--- a/新手小白请使用这个代码  不需要使用真机的专用代码/wechat_jump.py
+++ b/新手小白请使用这个代码  不需要使用真机的专用代码/wechat_jump.py
@@ -7,8 +7,8 @@ import time
 import os
 
 def pull_screenshot():
-    os.system('adb shell screencap -p /sdcard/1.png')
-    os.system('adb pull /sdcard/1.png .')
+    os.system('adb shell screencap -p /sdcard/autojump.png')
+    os.system('adb pull /sdcard/autojump.png .')
 
 def jump(distance):
     press_time = distance * 2.0
@@ -22,14 +22,14 @@ index = 0
 cor = [0, 0]
 
 pull_screenshot()
-img = np.array(Image.open('1.png'))
+img = np.array(Image.open('autojump.png'))
 
 update = True 
 click_count = 0
 cor = []
 
 def update_data():
-    return np.array(Image.open('1.png'))
+    return np.array(Image.open('autojump.png'))
 
 im = plt.imshow(img, animated=True)
 


### PR DESCRIPTION
1. Replace all 1.png to autojump.png since README contains autojump.png
2. 1.png is ambiguous and misleading. Ambiguity leads to mistakes.