### PR TITLE
修复自动脚本的bug:  IOError cannot identify image file autojump.png

### DIFF
--- a/wechat_jump_auto.py
+++ b/wechat_jump_auto.py
@@ -79,7 +79,7 @@ def pull_screenshot():
     process = subprocess.Popen('adb shell screencap -p', shell=True, stdout=subprocess.PIPE)
     screenshot = process.stdout.read()
     if sys.platform == 'win32':
-        screenshot = screenshot.replace(b'\r\n', b'\n')
+        screenshot = screenshot.replace(b'\r\r\n', b'\n')
     f = open('autojump.png', 'wb')
     f.write(screenshot)
     f.close()


### PR DESCRIPTION
通过检查 autojump.png 发现，应该将win32图片二进制\r\r\n 替换为 \n，不再出现 IOError cannot identify image file autojump.png 的bug