### PR TITLE
提交vivo 960x540 2000+配置

### DIFF
--- a/config/960x540/config.json
+++ b/config/960x540/config.json
@@ -1,0 +1,6 @@
+{
+    "under_game_score_y": 300, 
+    "press_coefficient": 2.732, 
+    "piece_base_height_1_2": 20, 
+    "piece_body_width": 70
+}


### PR DESCRIPTION
vivo 手机，960x540分辨率，修改按压时间比例系数，跑分2000+没问题