### PR TITLE
更新 1920*1080 蓄力系数

### DIFF
--- a/config/1920x1080/config.json
+++ b/config/1920x1080/config.json
@@ -1,6 +1,6 @@
 {
     "under_game_score_y": 300,
-    "press_coefficient": 1.392,
+    "press_coefficient": 1.44,
     "piece_base_height_1_2": 20,
     "piece_body_width": 70,
     "swipe" : {


### PR DESCRIPTION
使用Mi6进行测试， 由于当前版本默认使用屏幕尺寸寻找Config文件，故而更新之 。 主要解决力量不足导致的诸多问题。
问题扩展可以理解成为 ，平面图像的距离无法正确拟合立体坐标系。 所以才会生成当前的不同屏幕尺寸的蓄力拟合