### PR TITLE
Create 720x1280 （Android Bluestacks 模拟器）

### DIFF
--- a/config/720x1280
+++ b/config/720x1280
@@ -1,4 +1,3 @@
-
 {
     "under_game_score_y": 369,
     "press_coefficient":  2.003,

--- a/config/720x1280
+++ b/config/720x1280
@@ -1,0 +1,13 @@
+
+{
+    "under_game_score_y": 369,
+    "press_coefficient":  2.003,
+    "piece_base_height_1_2": 13,
+    "piece_body_width": 45,
+    "swipe" : {
+      "x1": 374,
+      "y1": 1060,
+      "x2": 374,
+      "y2": 1060
+    }
+}


### PR DESCRIPTION
Android Bluestacks 模拟器
分辨率 720*1280
所有参数如下（完美运行）
@AlienMarkWang提供

