### PR TITLE
1) modify computation of jump distance; 2)optimize waiting time before screenshooting

### DIFF
--- a/config/1920x1080/config.json
+++ b/config/1920x1080/config.json
@@ -1,12 +1,12 @@
 {
     "under_game_score_y": 300,
-    "press_coefficient": 1.392,
+    "press_coefficient": 1.38,
     "piece_base_height_1_2": 20,
     "piece_body_width": 70,
     "swipe" : {
       "x1": 500,
       "y1": 1600,
       "x2": 500,
-      "y2": 1602
+      "y2": 1600
     }
 }

--- a/wechat_jump_auto.py
+++ b/wechat_jump_auto.py
@@ -148,7 +148,7 @@ def find_piece_and_board(im):
         board_x_start = 0
         board_x_end = piece_x
 
-    for i in range(int(h / 3), int(h * 2 / 3)):
+    for i in range(int(h / 3), piece_y):
         last_pixel = im_pixel[0, i]
         if board_x or board_y:
             break
@@ -167,7 +167,7 @@ def find_piece_and_board(im):
                 board_x_c += 1
         if board_x_sum:
             board_x = board_x_sum / board_x_c
-    last_pixel = im_pixel[board_x, i]
+    last_pixel = im_pixel[board_x, i+2]
 
     #从上顶点往下+274的位置开始向上找颜色与上顶点一样的点，为下顶点
     #该方法对所有纯色平面和部分非纯色平面有效，对高尔夫草坪面、木纹桌面、药瓶和非菱形的碟机（好像是）会判断错误
@@ -181,15 +181,15 @@ def find_piece_and_board(im):
     #若上一跳由于某种原因没有跳到正中间，而下一跳恰好有无法正确识别花纹，则有可能游戏失败，由于花纹面积通常比较大，失败概率较低
     for l in range(i, i+200):
         pixel = im_pixel[board_x, l]
-        if abs(pixel[0] - 245) + abs(pixel[1] - 245) + abs(pixel[2] - 245) == 0:
-            board_y = l+10
+        if abs(pixel[0] - 245) + abs(pixel[1] - 245) + abs(pixel[2] - 245) <= 1:
+            board_y = l+11
             break
 
 
 
     if not all((board_x, board_y)):
         return 0, 0, 0, 0
-
+    piece_y = piece_y_max + piece_base_height_1_2
     return piece_x, piece_y, board_x, board_y
 
 
@@ -231,7 +231,7 @@ def main():
         if debug_switch:
             Debug.save_debug_screenshot(ts, im, piece_x, piece_y, board_x, board_y)
             Debug.backup_screenshot(ts)
-        time.sleep(1)   # 为了保证截图的时候应落稳了，多延迟一会儿
+        time.sleep(1.5+0.5*(random.random()-0.5))   # 为了保证截图的时候应落稳了，多延迟一会儿
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1）在3D游戏中每次跳跃的距离是应该三维欧式距离计算的，游戏通过虚拟相机成像映射到2D手机屏幕图片上，然后本脚本以图片上两点间的距离来线性表征原距离。但每次计算距离时原程序又加上了棋子高度的一半，以棋子中心点到目标方块中心点作为距离，这种计算方式在严格的线形估计上是有偏差的，具体表现为离得很近与离得很远时估算不一样，无法做到精确且连续估计跳到中心combo点。Fix：因为所有的物体都是等高的，只要以目标方块中心点为终点，和棋子脚下的中心点来计算距离，就是最准确的线形映射。改掉本问题后（也要结合第二条）（而且因为这样计算距离会增大，我适当减小了config/1920*1080下的跳跃系数），使得可以快速连续32分combo不间断，大大增加了连续加分combo的稳定性。
(另外，如果确定左上↖️和右上↗️的斜率是相同且不变的，那么只用x坐标就够了，因为根号里面的x可以提出来，只乘以一个系数)
2）今天运行时发现了一个问题，如下面两图所示，图1是本次跳跃之前，有着连续combo加分，图2是下一次的跳跃，发现没有跳到中心去，仔细分析发现是因为图1中combo奖励提示的白边没有完全消失（仔细看会发现图1棋子的一圈白边），这圈白边导致像素判定时目标x坐标估计错误，从而不能跳到中心。这种情况是因为combo加分特效1秒钟没有完全消失，所以应该增加等待时间。我增加到1.25秒到1.75秒之间，随机波动(防止检测)。

![image-1](https://user-images.githubusercontent.com/20136960/34486200-91e48990-f009-11e7-83d5-0662497d2a1e.png)
![image-2](https://user-images.githubusercontent.com/20136960/34486201-924f64a4-f009-11e7-8826-fd5337c6fda4.png)

3）本次测试使用小米6，1920**1080，所以我只更改并测试了1920*1080的配置文件，以及安卓的自动程序，测试了两次，一次7000分我自己关掉了，一次9000分还没死我自己关掉了，期间比较稳定，80%都在32分的combo加成中。

ps：又试了次16000分都没死