### PR TITLE
修复微信反作弊问题

### DIFF
--- a/wechat_jump_auto_iOS.py
+++ b/wechat_jump_auto_iOS.py
@@ -64,7 +64,7 @@ def pull_screenshot():
 def jump(distance):
     press_time = distance * time_coefficient / 1000
     print('press time: {}'.format(press_time))
-    s.tap_hold(200, 200, press_time)
+    s.tap_hold(random.randint(150,250), random.randint(728,850), press_time)
 
 
 def backup_screenshot(ts):


### PR DESCRIPTION
微信针对同一坐标的点击有反作弊。重启微信后得分就不算数了。
这里使用随机数后得分可以正常上榜