### PR TITLE
增加小米MIX2配置文件

### DIFF
--- a/config/mi/mix2_config.json
+++ b/config/mi/mix2_config.json
@@ -1,0 +1,6 @@
+{
+    "under_game_score_y": 420,
+    "press_coefficient": 1.480, 
+    "piece_base_height_1_2": 25,
+    "piece_body_width": 85
+}


### PR DESCRIPTION
1.48可以达到80%以上的中心命中，默认值只有40%。目前最高分805（原来454）

<!--
感谢您的 pull request!

## Python 文件修改，在 PR 前请尽量做到：
- PR 应基于最新的 dev 分支
```
  git remote add wangshub https://github.com/wangshub/wechat_jump_game.git
  git fetch
  git rebase wangshub/dev
```
- 更新脚本中的 VERSION 字段
- 尽量遵守 PEP8 规范
- Base 选择 dev 分支

## 文档及配置文件修改，在 PR 前请尽量做到：
- PR 应基于最新的 master 分支
```
  git remote add wangshub https://github.com/wangshub/wechat_jump_game.git
  git fetch
  git rebase wangshub/master
```
- Base 选择 master 分支

## 所有 PR 提交前：
- 分支名是有意义的名称，如 add-config-file-for-mi5s 而不是 patch-1
- 请描述一下 PR 做的事情，更新算法或配置文件请附上最高分数
- 请明确提交类型，为 PR 标题添加前缀：[类型]（类型可填写文档，配置，优化，修复等）

-->

本次 PR 主要做的事情：

- 增加小米MIX2配置文件

修改后最高分数：805
