### PR TITLE
更新距离与时间的计算关系（根据跳一跳源码计算）

### DIFF
--- a/config/1920x1080/config.json
+++ b/config/1920x1080/config.json
@@ -3,7 +3,7 @@
     "press_coefficient": 1.392,
     "piece_base_height_1_2": 20,
     "piece_body_width": 70,
-	"head_diameter":60,
+    "head_diameter": 60,
     "swipe": {
         "x1": 500,
         "y1": 1600,

--- a/config/1920x1080/config.json
+++ b/config/1920x1080/config.json
@@ -3,6 +3,7 @@
     "press_coefficient": 1.392,
     "piece_base_height_1_2": 20,
     "piece_body_width": 70,
+	"head_diameter":60,
     "swipe": {
         "x1": 500,
         "y1": 1600,

--- a/wechat_jump_auto.py
+++ b/wechat_jump_auto.py
@@ -33,7 +33,7 @@ except Exception as ex:
     print('请检查项目根目录中的 common 文件夹是否存在')
     exit(-1)
 
-VERSION = "1.1.1"
+VERSION = "1.2.1"
 
 # DEBUG 开关，需要调试的时候请改为 True，不需要调试的时候为 False
 DEBUG_SWITCH = False
@@ -49,7 +49,7 @@ piece_base_height_1_2 = config['piece_base_height_1_2']
 # 棋子的宽度，比截图中量到的稍微大一点比较安全，可能要调节
 piece_body_width = config['piece_body_width']
 # 图形中圆球的直径，可以利用系统自带画图工具，用直线测量像素，如果可以实现自动识别圆球直径，那么此处将可实现全自动。
-head_diameter = config['head_diameter']
+head_diameter = config.get('head_diameter', 60)
 
 
 def set_button_position(im):

--- a/wechat_jump_auto.py
+++ b/wechat_jump_auto.py
@@ -16,13 +16,15 @@
 最后：根据两点的坐标算距离乘以系数来获取长按时间（似乎可以直接用 X 轴距离）
 """
 from __future__ import print_function, division
+
+import math
 import os
+import random
 import sys
 import time
-import math
-import random
 from PIL import Image
 from six.moves import input
+
 try:
     from common import debug, config, screenshot
 except Exception as ex:
@@ -31,12 +33,10 @@ except Exception as ex:
     print('请检查项目根目录中的 common 文件夹是否存在')
     exit(-1)
 
-
 VERSION = "1.1.1"
 
 # DEBUG 开关，需要调试的时候请改为 True，不需要调试的时候为 False
 DEBUG_SWITCH = False
-
 
 # Magic Number，不设置可能无法正常执行，请根据具体截图从上到下按需
 # 设置，设置保存在 config 文件夹中
@@ -48,6 +48,8 @@ press_coefficient = config['press_coefficient']
 piece_base_height_1_2 = config['piece_base_height_1_2']
 # 棋子的宽度，比截图中量到的稍微大一点比较安全，可能要调节
 piece_body_width = config['piece_body_width']
+# 图形中圆球的直径，可以利用系统自带画图工具，用直线测量像素，如果可以实现自动识别圆球直径，那么此处将可实现全自动。
+head_diameter = config['head_diameter']
 
 
 def set_button_position(im):
@@ -58,8 +60,8 @@ def set_button_position(im):
     w, h = im.size
     left = int(w / 2)
     top = int(1584 * (h / 1920.0))
-    left = int(random.uniform(left-50, left+50))
-    top = int(random.uniform(top-10, top+10))    # 随机防 ban
+    left = int(random.uniform(left - 50, left + 50))
+    top = int(random.uniform(top - 10, top + 10))  # 随机防 ban
     swipe_x1, swipe_y1, swipe_x2, swipe_y2 = left, top, left, top
 
 
@@ -67,8 +69,11 @@ def jump(distance):
     """
     跳跃一定的距离
     """
-    press_time = distance * press_coefficient
-    press_time = max(press_time, 200)   # 设置 200ms 是最小的按压时间
+    # 计算程序长度与截图测得的距离的比例
+    scale = 0.945 * 2 / head_diameter
+    actual_distance = distance * scale * (math.sqrt(6) / 2)
+    press_time = (-945 + math.sqrt(945 ** 2 + 4 * 105 * 36 * actual_distance)) / (2 * 105) * 1000
+    press_time = max(press_time, 200)  # 设置 200ms 是最小的按压时间
     press_time = int(press_time)
     cmd = 'adb shell input swipe {x1} {y1} {x2} {y2} {duration}'.format(
         x1=swipe_x1,
@@ -97,7 +102,7 @@ def find_piece_and_board(im):
     scan_start_y = 0  # 扫描的起始 y 坐标
     im_pixel = im.load()
     # 以 50px 步长，尝试探测 scan_start_y
-    for i in range(int(h / 3), int(h*2 / 3), 50):
+    for i in range(int(h / 3), int(h * 2 / 3), 50):
         last_pixel = im_pixel[0, i]
         for j in range(1, w):
             pixel = im_pixel[j, i]
@@ -129,7 +134,7 @@ def find_piece_and_board(im):
     piece_y = piece_y_max - piece_base_height_1_2  # 上移棋子底盘高度的一半
 
     # 限制棋盘扫描的横坐标，避免音符 bug
-    if piece_x < w/2:
+    if piece_x < w / 2:
         board_x_start = piece_x
         board_x_end = w
     else:
@@ -162,19 +167,19 @@ def find_piece_and_board(im):
     # 从上顶点往下 +274 的位置开始向上找颜色与上顶点一样的点，为下顶点
     # 该方法对所有纯色平面和部分非纯色平面有效，对高尔夫草坪面、木纹桌面、
     # 药瓶和非菱形的碟机（好像是）会判断错误
-    for k in range(i+274, i, -1):  # 274 取开局时最大的方块的上下顶点距离
+    for k in range(i + 274, i, -1):  # 274 取开局时最大的方块的上下顶点距离
         pixel = im_pixel[board_x, k]
         if abs(pixel[0] - last_pixel[0]) \
                 + abs(pixel[1] - last_pixel[1]) \
                 + abs(pixel[2] - last_pixel[2]) < 10:
             break
-    board_y = int((i+k) / 2)
+    board_y = int((i + k) / 2)
 
     # 如果上一跳命中中间，则下个目标中心会出现 r245 g245 b245 的点，利用这个
     # 属性弥补上一段代码可能存在的判断错误
     # 若上一跳由于某种原因没有跳到正中间，而下一跳恰好有无法正确识别花纹，则有
     # 可能游戏失败，由于花纹面积通常比较大，失败概率较低
-    for j in range(i, i+200):
+    for j in range(i, i + 200):
         pixel = im_pixel[board_x, j]
         if abs(pixel[0] - 245) + abs(pixel[1] - 245) + abs(pixel[2] - 245) == 0:
             board_y = j + 10
@@ -191,7 +196,7 @@ def yes_or_no(prompt, true_value='y', false_value='n', default=True):
     """
     default_value = true_value if default else false_value
     prompt = '{} {}/{} [{}]: '.format(prompt, true_value,
-        false_value, default_value)
+                                      false_value, default_value)
     i = input(prompt)
     if not i:
         return default


### PR DESCRIPTION

本次 PR 主要做的事情：

- 根据官网源码推导出的计算公式
- 增加head_diameter参数，即棋子顶部圆球的直径。
- 获取截图测得的距离，通过比例换算得到在代码中的距离长度
- 从此不需要再去一个个试参数，只需要测量顶部圆球的直径即可，测试的机子使用
  1920x1080，截图中圆球直径是60px。


- TODO : 如果可以加入自动测量圆球直径的代码，则可实现全自动，无须手动测量。
- TODO : 由于游戏视角是倾斜了60°的，因此截图测得的长度与代码中的长度有个关系存在，目前
  math.sqrt(6) / 2这个值是根据每次倾斜都是圆心到圆心测量的，因为确实每次跳跃都在combo。即使不
 是圆心到圆心，误差也不大，如果想确保计算严谨性，那么这个比例需要根据每次倾斜的角度，并且需要知道原路径是怎么样的一个角度才能得到截图中测得的角度。

修改后最高分数：2000多分，主动退了。
