### PR TITLE
[修复] 对 fcbe89bd9d0 提交中 updatefig 方法误删函数参数进行修复

### DIFF
--- a/wechat_jump.py
+++ b/wechat_jump.py
@@ -58,7 +58,7 @@ im = plt.imshow(img, animated=True)
 update = True
 
 
-def updatefig():
+def updatefig(*args):
     global update
 
     if update:

--- a/wechat_jump_iOS_py3.py
+++ b/wechat_jump_iOS_py3.py
@@ -43,7 +43,7 @@ def update_data():
     return np.array(Image.open('autojump.png'))
 
 
-def updatefig():
+def updatefig(*args):
     global update
     if update:
         time.sleep(1)

--- a/wechat_jump_py3.py
+++ b/wechat_jump_py3.py
@@ -34,7 +34,7 @@ def update_data():
     return np.array(Image.open('autojump.png'))
 
 
-def updatefig():
+def updatefig(*args):
     global update
     if update:
         time.sleep(1.5)


### PR DESCRIPTION
<!--
感谢您的 pull request!

## Python 文件修改，在 PR 前请尽量做到：
- PR 应基于最新的 dev 分支
```
  git remote add wangshub https://github.com/wangshub/wechat_jump_game.git
  git fetch
  git rebase wangshub/dev
```
- 更新脚本中的 VERSION 字段
- 尽量遵守 PEP8 规范
- Base 选择 dev 分支

## 文档及配置文件修改，在 PR 前请尽量做到：
- PR 应基于最新的 master 分支
```
  git remote add wangshub https://github.com/wangshub/wechat_jump_game.git
  git fetch
  git rebase wangshub/master
```
- Base 选择 master 分支

## 所有 PR 提交前：
- 分支名是有意义的名称，如 add-config-file-for-mi5s 而不是 patch-1
- 请描述一下 PR 做的事情，更新算法或配置文件请附上最高分数
- 请明确提交类型，为 PR 标题添加前缀：[类型]（类型可填写文档，配置，优化，修复等）

-->

本次 PR 主要做的事情：

- 对 fcbe89b 提交中 updatefig 方法误删函数参数进行修复，updatefig 方法虽然参数没有被用到，但是它必须传入参数。早上改的时候没有测试，直接给删了。现在补回来。


  