### PR TITLE
[修复]不能正确读取当前目录配置文件

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -17,6 +17,13 @@ def open_accordant_config():
         path=sys.path[0],
         screen_size=screen_size
     )
+    # 优先获取执行文件目录的配置文件
+    if _get_customized_config():
+        with open(_get_customized_config(), 'r') as f:
+            print("Load config file from {}".format(_get_customized_config()))
+            return json.load(f)
+
+    # 根据分辨率查找配置文件
     if os.path.exists(config_file):
         with open(config_file, 'r') as f:
             print("Load config file from {}".format(config_file))
@@ -39,3 +46,14 @@ def _get_screen_size():
     if m:
         return "{height}x{width}".format(height=m.group(2), width=m.group(1))
     return "1920x1080"
+
+
+def _get_customized_config():
+    """
+    查看当前目录下是否存在json配置文件
+    """
+    here = sys.path[0]
+    for file in os.listdir(here):
+        if re.match('(.+)\.json', file):
+            return os.path.join(here, file)
+    return False


### PR DESCRIPTION
根据教程提示，可以将配置文件放在执行文件同一目录即可读取，但是程序依然优先读取问分辨率下的配置，导致大量机型无法正确适配

<!--
感谢您的 pull request!

## Python 文件修改，在 PR 前请尽量做到：
- PR 应基于最新的 dev 分支
```
  git remote add wangshub https://github.com/wangshub/wechat_jump_game.git
  git fetch
  git rebase wangshub/dev
```
- 更新脚本中的 VERSION 字段
- 尽量遵守 PEP8 规范
- Base 选择 dev 分支

## 文档及配置文件修改，在 PR 前请尽量做到：
- PR 应基于最新的 master 分支
```
  git remote add wangshub https://github.com/wangshub/wechat_jump_game.git
  git fetch
  git rebase wangshub/master
```
- Base 选择 master 分支

## 所有 PR 提交前：
- 分支名是有意义的名称，如 add-config-file-for-mi5s 而不是 patch-1
- 请描述一下 PR 做的事情，更新算法或配置文件请附上最高分数
- 请明确提交类型，为 PR 标题添加前缀：[类型]（类型可填写文档，配置，优化，修复等）

-->

本次 PR 主要做的事情：

- x 将配置文件放在执行文件同一目录即可读取

修改后最高分数：10000分以上