### PR TITLE
[优化]添加截图获取方式，直接从stdout中获取图像，不在本地保存图片

### DIFF
--- a/common/screenshot.py
+++ b/common/screenshot.py
@@ -6,6 +6,8 @@ import subprocess
 import os
 import sys
 from PIL import Image
+import numpy as np
+import cv2
 
 
 # SCREENSHOT_WAY 是截图方法，经过 check_screenshot 后，会自动递减，不需手动修改
@@ -30,6 +32,22 @@ def pull_screenshot():
         f = open('autojump.png', 'wb')
         f.write(binary_screenshot)
         f.close()
+
+        # 将binary_screenshot直接转化为uint8数组，可直接用opencv的imdecode进行解码并读图图像，图像可以直接读入内存中，减少硬盘I/O。
+        # 具体流程为捕获adb shell screencap -p的stdout，转化为uint8数组，用opencv的imdecode进行读取。
+        # 如果脚本中用opencv处理图像的话，应该可以减少I/O的时间
+        # 在我本机测试中，只有SCREENSHOT_WAY == 1时imdecode是正常的，其它情况matImage为空
+        # 第一次用python，不是很熟悉
+        rawArray = np.zeros(binary_screenshot.__len__(), dtype=np.uint8)
+        for i in range(0, binary_screenshot.__len__()):
+            rawArray[i] = binary_screenshot[i]
+        matImage = cv2.imdecode(rawArray,cv2.IMREAD_COLOR)
+
+        # 若imdecode失败，则matImage的类型为NoneType，成功则为nmupy.ndarry
+        if isinstance(matImage,np.ndarray):
+            cv2.imshow("1",matImage)
+            cv2.waitKey()
+
     elif SCREENSHOT_WAY == 0:
         os.system('adb shell screencap -p /sdcard/autojump.png')
         os.system('adb pull /sdcard/autojump.png .')
@@ -55,3 +73,6 @@ def check_screenshot():
     except Exception:
         SCREENSHOT_WAY -= 1
         check_screenshot()
+
+
+check_screenshot()


### PR DESCRIPTION
本次 PR 主要做的事情：

- 添加截图获取方式，直接从stdout中获取图像，不在本地保存图片。            

          
具体流程为捕获adb shell screencap -p的stdout，转化为uint8数组，用opencv的imdecode进行读取。如果后续用opencv处理图像的话，就不用再磁盘上写入或读取文件，减少磁盘和手机的I/O，应该能使脚本快一点吧？第一次用Python，也是第一次在Python上用opencv，没敢加太多东西，如果该方法验证可行的话，可以加到其他脚本中。由以往的两条adb指令减少为一条指令，去除写入和读取文件。